### PR TITLE
Fix differing cases

### DIFF
--- a/notetypes.py
+++ b/notetypes.py
@@ -14,7 +14,7 @@ config = mw.addonManager.getConfig(__name__)
 def isJapaneseNoteType(noteName):
     noteName = noteName.lower()
     for allowedString in config["noteTypes"]:
-        if allowedString in noteName:
+        if allowedString.lower() in noteName:
             return True
 
     return False


### PR DESCRIPTION
My note types had capitals, which would not match with the noteName because it is turned into lowercase.
This fixes the problem.